### PR TITLE
feat(cli): add yarn pnp support

### DIFF
--- a/packages/gatsby-cli/src/create-cli.js
+++ b/packages/gatsby-cli/src/create-cli.js
@@ -298,10 +298,20 @@ module.exports = (argv, handlers) => {
     .command({
       command: `new [rootPath] [starter]`,
       desc: `Create new Gatsby project.`,
+      builder: _ =>
+        _.option(`use-pnp`, {
+          type: `boolean`,
+          default: false,
+          describe: `Use yarn Plug'n'Play to install dependencies`,
+        }),
       handler: handlerP(
-        ({ rootPath, starter = `gatsbyjs/gatsby-starter-default` }) => {
+        ({
+          rootPath,
+          starter = `gatsbyjs/gatsby-starter-default`,
+          "use-pnp": usePnp,
+        }) => {
           const initStarter = require(`./init-starter`)
-          return initStarter(starter, { rootPath })
+          return initStarter(starter, { rootPath, usePnp })
         }
       ),
     })

--- a/packages/gatsby-cli/src/init-starter.js
+++ b/packages/gatsby-cli/src/init-starter.js
@@ -34,12 +34,17 @@ const install = async (rootPath, usePnp) => {
   report.info(`Installing packages...`)
   process.chdir(rootPath)
 
+  let cmd
+
+  if (shouldUseYarn()) {
+    cmd = `yarnpkg${usePnp ? ` --pnp` : ``}`
+  } else {
+    usePnp && report.warn(`NPM does not support PnP, ignoring --use-pnp...`)
+    cmd = `npm install`
+  }
+
   try {
-    // TODO: If yarn version under 1.2 or NPM is being used, warn user.
-    let cmd = shouldUseYarn()
-      ? spawn(`yarnpkg${usePnp ? ` --pnp` : ``}`)
-      : spawn(`npm install`)
-    await cmd
+    await spawn(cmd)
   } finally {
     process.chdir(prevDir)
   }

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -93,6 +93,7 @@
     "optimize-css-assets-webpack-plugin": "^5.0.1",
     "parse-filepath": "^1.0.1",
     "physical-cpu-count": "^2.0.0",
+    "pnp-webpack-plugin": "^1.2.0",
     "postcss-flexbugs-fixes": "^3.0.0",
     "postcss-loader": "^2.1.3",
     "raw-loader": "^0.5.1",

--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -4,6 +4,7 @@ const fs = require(`fs-extra`)
 const path = require(`path`)
 const dotenv = require(`dotenv`)
 const FriendlyErrorsWebpackPlugin = require(`friendly-errors-webpack-plugin`)
+const PnpWebpackPlugin = require(`pnp-webpack-plugin`)
 const { store } = require(`../redux`)
 const { actions } = require(`../redux/actions`)
 const debug = require(`debug`)(`gatsby:webpack-config`)
@@ -350,6 +351,10 @@ module.exports = async (
   function getResolve() {
     const { program } = store.getState()
     return {
+      plugins: [
+        // Adds support for yarn plug'n'play
+        PnpWebpackPlugin,
+      ],
       // Use the program's extension list (generated via the
       // 'resolvableExtensions' API hook).
       extensions: [...program.extensions],
@@ -392,6 +397,10 @@ module.exports = async (
     }
 
     return {
+      plugins: [
+        // Plug'n'Play: Tell webpack to load from the current package
+        PnpWebpackPlugin.moduleLoader(module),
+      ],
       modules: [...root, path.join(__dirname, `../loaders`), `node_modules`],
     }
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -14670,6 +14670,13 @@ pngquant-bin@^5.0.0:
     execa "^0.10.0"
     logalot "^2.0.0"
 
+pnp-webpack-plugin@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/pnp-webpack-plugin/-/pnp-webpack-plugin-1.2.0.tgz#a85338bc313b8a0469c1d8c5c5d016873be47cb2"
+  integrity sha512-cCaqL7SZCqeJoCEL5GhSGU9CFJOMcDIEAS83X+0m2q25vtt9IqrMJ5dObm8WyqnM4CHRaIn0VVkn7RXdZ0C6Kg==
+  dependencies:
+    ts-pnp "^1.0.0"
+
 portfinder@^1.0.9:
   version "1.0.17"
   resolved "https://registry.yarnpkg.com/portfinder/-/portfinder-1.0.17.tgz#a8a1691143e46c4735edefcf4fbcccedad26456a"
@@ -18663,6 +18670,11 @@ trough@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/trough/-/trough-1.0.3.tgz#e29bd1614c6458d44869fc28b255ab7857ef7c24"
   integrity sha512-fwkLWH+DimvA4YCy+/nvJd61nWQQ2liO/nF/RjkTpiOGi+zxZzVkhb1mvbHIIW4b/8nDsYI8uTmAlc0nNkRMOw==
+
+ts-pnp@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.0.0.tgz#44a3a9e8c13fcb711bcda75d7b576c21af120c9d"
+  integrity sha512-qgwM7eBrxFvZSXLtSvjf3c2mXwJOOGD49VlE+KocUGX95DuMdLc/psZHBnPpZL5b2NU7VtQGHRCWF3cNfe5kxQ==
 
 tsickle@^0.27.2:
   version "0.27.5"


### PR DESCRIPTION
This PR adds yarn Plug'n'Play support, but it's still a work in progress.

Here's what I've got working so far:

- cli now has the `--use-pnp` flag you can pass to enable pnp
- when using pnp, there's no `node_modules` folder and we can find a `.pnp.js` file and `.pnp` folder
- webpack config now loads the pnp plugin for resolve and resolveLoader

### Benchmarks

I measured the time it takes for `gatsby new` command  to complete with and without the `--use-pnp` flag, and got unexpected results:

- `gatsby new /tmp/gatsby-test`: 29.1 seconds
- `gatsby new /tmp/gatsby-pnp-test --use-pnp`: 33.4 seconds

This is totally unexpected since the whole purpose of using PnP is that it's a lot faster to install packages. I was obvious that something was wrong here, so I ran and measured the yarn command isolated inside `/tmp/gatsby-test` (removing the `node_modules`folder before and in between runs):

- `yarn`: 21.6 seconds
- `yarn --pnp`: 3.2 seconds

These results are more inline with what we're expecting. So I'd need more time to figure out why using gatsby-cli I get completely different results.